### PR TITLE
Add compilation, CLI, log parser, health checks, and module refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = []
 
+[project.scripts]
+pytinytex = "pytinytex.cli:main"
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",

--- a/pytinytex/__init__.py
+++ b/pytinytex/__init__.py
@@ -1,13 +1,18 @@
-import asyncio
 import logging
 import os
 import platform
-import shutil
 import sys
 import warnings
-from pathlib import Path
 
 from .tinytex_download import download_tinytex, DEFAULT_TARGET_FOLDER  # noqa
+from .log_parser import LogEntry, ParsedLog, parse_log  # noqa
+from .compiler import CompileResult, compile  # noqa
+from .doctor import DoctorCheck, DoctorResult, doctor  # noqa
+from .tlmgr import (  # noqa
+	install, remove, list_installed, search, info, update,
+	help, shell, get_version, uninstall,
+	_run_tlmgr_command, _parse_tlmgr_list, _parse_tlmgr_info,
+)
 
 logger = logging.getLogger("pytinytex")
 logger.addHandler(logging.NullHandler())
@@ -39,140 +44,15 @@ __all__ = [
 	"uninstall",
 	"help",
 	"shell",
+	"compile",
+	"CompileResult",
+	"LogEntry",
+	"ParsedLog",
+	"parse_log",
+	"doctor",
+	"DoctorResult",
+	"DoctorCheck",
 ]
-
-
-# --- Package management ---
-
-def install(package):
-	"""Install a TeX Live package via tlmgr.
-
-	Args:
-		package: Package name (e.g. "booktabs", "amsmath").
-
-	Returns:
-		Tuple of (exit_code, output).
-	"""
-	path = get_tinytex_path()
-	return _run_tlmgr_command(["install", package], path, False)
-
-def remove(package):
-	"""Remove a TeX Live package via tlmgr.
-
-	Args:
-		package: Package name to remove.
-
-	Returns:
-		Tuple of (exit_code, output).
-	"""
-	path = get_tinytex_path()
-	return _run_tlmgr_command(["remove", package], path, False)
-
-def list_installed():
-	"""List all installed TeX Live packages.
-
-	Returns:
-		List of dicts with keys such as 'name', 'installed', 'detail'.
-	"""
-	path = get_tinytex_path()
-	_, output = _run_tlmgr_command(["list", "--only-installed"], path, True)
-	return _parse_tlmgr_list(output)
-
-def search(query):
-	"""Search for TeX Live packages matching a query.
-
-	Args:
-		query: Search term (package name or keyword).
-
-	Returns:
-		List of dicts with keys such as 'name', 'description'.
-	"""
-	path = get_tinytex_path()
-	_, output = _run_tlmgr_command(["search", query], path, True)
-	return _parse_tlmgr_list(output)
-
-def info(package):
-	"""Get detailed information about a TeX Live package.
-
-	Args:
-		package: Package name.
-
-	Returns:
-		Dict with package metadata (keys vary by package, but typically
-		include 'package', 'revision', 'cat-version', 'category',
-		'shortdesc', 'longdesc', 'installed', 'sizes', etc.).
-	"""
-	path = get_tinytex_path()
-	_, output = _run_tlmgr_command(["info", package], path, True)
-	return _parse_tlmgr_info(output)
-
-def update(package="-all"):
-	"""Update TeX Live packages via tlmgr.
-
-	Args:
-		package: Package name to update, or "-all" (default) to update
-			everything.
-
-	Returns:
-		Tuple of (exit_code, output).
-	"""
-	path = get_tinytex_path()
-	return _run_tlmgr_command(["update", package], path, False)
-
-def help():
-	"""Display tlmgr help text.
-
-	Returns:
-		Tuple of (exit_code, output).
-	"""
-	path = get_tinytex_path()
-	return _run_tlmgr_command(["help"], path, False)
-
-def shell():
-	"""Open an interactive tlmgr shell session."""
-	path = get_tinytex_path()
-	return _run_tlmgr_command(["shell"], path, False, True)
-
-def get_version():
-	"""Return the installed TeX Live / TinyTeX version string.
-
-	Returns:
-		Version string as reported by ``tlmgr --version``.
-	"""
-	path = get_tinytex_path()
-	_, output = _run_tlmgr_command(["--version"], path, False)
-	return output.strip()
-
-def uninstall(path=None):
-	"""Remove the TinyTeX installation from disk and clear the path cache.
-
-	Args:
-		path: Directory to remove.  Defaults to the currently resolved
-			TinyTeX path (or DEFAULT_TARGET_FOLDER).
-	"""
-	global __tinytex_path
-	if not path:
-		path = __tinytex_path or str(DEFAULT_TARGET_FOLDER)
-	# Walk up from the bin directory to the installation root.
-	# __tinytex_path typically points at e.g. .pytinytex/bin/x86_64-linux,
-	# but the user likely means the top-level .pytinytex folder.
-	target = Path(path)
-	default = Path(DEFAULT_TARGET_FOLDER)
-	try:
-		is_under_default = default.exists() and target.is_relative_to(default)
-	except AttributeError:
-		# Path.is_relative_to() was added in Python 3.9
-		try:
-			target.relative_to(default)
-			is_under_default = default.exists()
-		except ValueError:
-			is_under_default = False
-	if is_under_default:
-		target = default
-	if target.exists():
-		shutil.rmtree(target)
-		logger.info("Removed TinyTeX installation at %s", target)
-	__tinytex_path = None
 
 
 # --- Path resolution ---
@@ -184,6 +64,9 @@ def get_tinytex_path(base=None):
 		base: Optional base directory to search in.  Falls back to the
 			``PYTINYTEX_TINYTEX`` environment variable, then
 			DEFAULT_TARGET_FOLDER.
+
+	Raises:
+		RuntimeError: If TinyTeX is not found.
 	"""
 	if __tinytex_path:
 		return __tinytex_path
@@ -200,6 +83,32 @@ def clear_path_cache():
 	"""Reset the cached TinyTeX path so the next call re-resolves it."""
 	global __tinytex_path
 	__tinytex_path = None
+
+def ensure_tinytex_installed(path=None):
+	"""Check that TinyTeX is installed and resolve the bin directory.
+
+	Args:
+		path: Path to check for TinyTeX. Defaults to the cached path or
+			DEFAULT_TARGET_FOLDER.
+
+	Returns:
+		True if TinyTeX is installed.
+
+	Raises:
+		RuntimeError: If TinyTeX is not found. Use
+			``download_tinytex()`` to install it first.
+	"""
+	global __tinytex_path
+	if not path:
+		path = __tinytex_path or DEFAULT_TARGET_FOLDER
+	__tinytex_path = _resolve_path(path)
+	# Ensure the resolved bin directory is on PATH for this process
+	_add_to_path(__tinytex_path)
+	return True
+
+def _tinytex_path():
+	"""Return the current cached path (or None). Used by submodules."""
+	return __tinytex_path
 
 
 # --- Engine discovery ---
@@ -255,104 +164,20 @@ def get_pdf_latex_engine():
 	return get_pdflatex_engine()
 
 
-# --- Installation ---
-
-def ensure_tinytex_installed(path=None, auto_download=True, variation=1):
-	"""Ensure TinyTeX is installed, optionally downloading it if missing.
-
-	Args:
-		path: Path to check for TinyTeX. Defaults to the cached path or
-			DEFAULT_TARGET_FOLDER.
-		auto_download: If True, download TinyTeX when it is not found.
-			Defaults to True.
-		variation: TinyTeX variation to download (0, 1, or 2) when
-			auto_download triggers. Defaults to 1.
-
-	Returns:
-		True if TinyTeX is installed (or was successfully downloaded).
-
-	Raises:
-		RuntimeError: If TinyTeX is not found and auto_download is False.
-	"""
-	global __tinytex_path
-	if not path:
-		path = __tinytex_path or DEFAULT_TARGET_FOLDER
-	try:
-		__tinytex_path = _resolve_path(path)
-	except RuntimeError:
-		if not auto_download:
-			raise
-		logger.info("TinyTeX not found — downloading automatically...")
-		download_tinytex(variation=variation, target_folder=path)
-		__tinytex_path = _resolve_path(path)
-	return True
-
-
-# --- Machine-readable output parsing ---
-
-def _parse_tlmgr_list(output):
-	"""Parse tlmgr list/search machine-readable output into structured data.
-
-	Machine-readable list lines look like:
-		i collection-basic: 1 file, 4k
-	or plain lines like:
-		package_name - short description
-
-	Returns a list of dicts.
-	"""
-	results = []
-	for line in output.splitlines():
-		line = line.strip()
-		if not line:
-			continue
-		if ":" in line:
-			# e.g. "i collection-basic: 12345 1 file, 4k"
-			parts = line.split(":", 1)
-			left = parts[0].strip()
-			right = parts[1].strip() if len(parts) > 1 else ""
-			installed = left.startswith("i")
-			name = left.lstrip("i").strip()
-			results.append({
-				"name": name,
-				"installed": installed,
-				"detail": right,
-			})
-		elif " - " in line:
-			name, desc = line.split(" - ", 1)
-			results.append({
-				"name": name.strip(),
-				"description": desc.strip(),
-			})
-		else:
-			results.append({"name": line})
-	return results
-
-def _parse_tlmgr_info(output):
-	"""Parse tlmgr info machine-readable output into a dict.
-
-	Info output is typically key-value pairs like:
-		package:    booktabs
-		revision:   12345
-		shortdesc:  Publication quality tables
-	Multi-line values (like longdesc) are continued with leading whitespace.
-	"""
-	info = {}
-	current_key = None
-	for line in output.splitlines():
-		if not line.strip():
-			continue
-		if ":" in line and not line[0].isspace():
-			key, _, value = line.partition(":")
-			key = key.strip().lower()
-			value = value.strip()
-			info[key] = value
-			current_key = key
-		elif current_key and line[0].isspace():
-			info[current_key] += " " + line.strip()
-	return info
-
-
 # --- Internal helpers ---
+
+def _is_on_path(directory):
+	"""Check if a directory is on the system PATH, with proper normalization."""
+	norm_dir = os.path.normcase(os.path.normpath(directory))
+	for entry in os.environ.get("PATH", "").split(os.pathsep):
+		if os.path.normcase(os.path.normpath(entry)) == norm_dir:
+			return True
+	return False
+
+def _add_to_path(directory):
+	"""Add a directory to the system PATH for this process if not already there."""
+	if not _is_on_path(directory):
+		os.environ["PATH"] = directory + os.pathsep + os.environ.get("PATH", "")
 
 def _get_platform_arch():
 	"""Return the TeX Live platform-architecture directory name for the current system."""
@@ -418,92 +243,3 @@ def _find_file(dir, prefix):
 	except FileNotFoundError:
 		pass
 	return None
-
-def _run_tlmgr_command(args, path, machine_readable=True, interactive=False):
-	if machine_readable:
-		if "--machine-readable" not in args:
-			args.insert(0, "--machine-readable")
-	tlmgr_executable = _find_file(path, "tlmgr")
-	if not tlmgr_executable:
-		raise RuntimeError(f"Unable to find tlmgr in {path}")
-	# resolve any symlinks
-	tlmgr_executable = str(Path(tlmgr_executable).resolve(True))
-	args.insert(0, tlmgr_executable)
-	new_env = os.environ.copy()
-	creation_flag = 0x08000000 if sys.platform == "win32" else 0
-
-	logger.debug("Running command: %s", args)
-	return asyncio.run(
-		_run_command(*args, stdin=interactive, env=new_env, creationflags=creation_flag)
-	)
-
-
-async def _read_stdout(process, output_buffer):
-	"""Read lines from process.stdout and collect them."""
-	logger.debug("Reading stdout from process %s", process.pid)
-	try:
-		while True:
-			line = await process.stdout.readline()
-			if not line:
-				break
-			line = line.decode('utf-8', errors='replace').rstrip()
-			output_buffer.append(line)
-			logger.info(line)
-	except Exception as e:
-		logger.error("Error in _read_stdout: %s", e)
-	finally:
-		process._transport.close()
-	return await process.wait()
-
-async def _send_stdin(process):
-	"""Read user input from sys.stdin and forward it to the process."""
-	logger.debug("Sending stdin to process %s", process.pid)
-	loop = asyncio.get_running_loop()
-	try:
-		while True:
-			user_input = await loop.run_in_executor(None, sys.stdin.readline)
-			if not user_input:
-				break
-			process.stdin.write(user_input.encode('utf-8'))
-			await process.stdin.drain()
-	except Exception as e:
-		logger.error("Error in _send_stdin: %s", e)
-	finally:
-		if process.stdin:
-			process._transport.close()
-
-
-async def _run_command(*args, stdin=False, **kwargs):
-	process = await asyncio.create_subprocess_exec(
-		*args,
-		stdout=asyncio.subprocess.PIPE,
-		stderr=asyncio.subprocess.STDOUT,
-		stdin=asyncio.subprocess.PIPE if stdin else asyncio.subprocess.DEVNULL,
-		**kwargs
-	)
-
-	output_buffer = []
-	stdout_task = asyncio.create_task(_read_stdout(process, output_buffer))
-	stdin_task = None
-	if stdin:
-		stdin_task = asyncio.create_task(_send_stdin(process))
-
-	try:
-		if stdin:
-			logger.debug("Waiting for stdout and stdin tasks to complete")
-			await asyncio.gather(stdout_task, stdin_task)
-		else:
-			logger.debug("Waiting for stdout task to complete")
-			await stdout_task
-		exit_code = await process.wait()
-	except KeyboardInterrupt:
-		process.terminate()
-		exit_code = await process.wait()
-	finally:
-		stdout_task.cancel()
-		if stdin_task:
-			stdin_task.cancel()
-	captured_output = "\n".join(output_buffer)
-	if exit_code != 0:
-		raise RuntimeError(f"Error running command: {captured_output}")
-	return exit_code, captured_output

--- a/pytinytex/__main__.py
+++ b/pytinytex/__main__.py
@@ -1,0 +1,7 @@
+"""Allow running pytinytex as ``python -m pytinytex``."""
+
+import sys
+
+from .cli import main
+
+sys.exit(main())

--- a/pytinytex/cli.py
+++ b/pytinytex/cli.py
@@ -158,22 +158,11 @@ def main(argv=None):
 				return 1
 
 		elif args.command == "download":
-			def _progress(downloaded, total):
-				if total > 0:
-					pct = downloaded * 100 // total
-					mb_down = downloaded / (1024 * 1024)
-					mb_total = total / (1024 * 1024)
-					sys.stdout.write(
-						"\r  Downloading: %.1f/%.1f MB (%d%%)" % (mb_down, mb_total, pct)
-					)
-					sys.stdout.flush()
-
 			pytinytex.download_tinytex(
 				version=getattr(args, "version", "latest"),
 				variation=args.variation,
-				progress_callback=_progress,
 			)
-			print("\nDone.")
+			print("Done.")
 
 		elif args.command == "uninstall":
 			pytinytex.uninstall(args.path)

--- a/pytinytex/cli.py
+++ b/pytinytex/cli.py
@@ -1,0 +1,186 @@
+"""Command-line interface for pytinytex."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv=None):
+	"""Entry point for ``python -m pytinytex``."""
+	parser = argparse.ArgumentParser(
+		prog="pytinytex",
+		description="Manage TinyTeX installations and compile LaTeX documents.",
+	)
+	sub = parser.add_subparsers(dest="command")
+
+	# compile
+	p_compile = sub.add_parser("compile", help="Compile a .tex file to PDF")
+	p_compile.add_argument("file", help="Path to the .tex file")
+	p_compile.add_argument("--engine", default="pdflatex",
+		choices=["pdflatex", "xelatex", "lualatex", "latex"],
+		help="LaTeX engine (default: pdflatex)")
+	p_compile.add_argument("--output-dir", default=None,
+		help="Output directory for generated files")
+	p_compile.add_argument("--runs", type=int, default=1,
+		help="Number of compilation passes (default: 1)")
+	p_compile.add_argument("--auto-install", action="store_true",
+		help="Automatically install missing packages")
+	p_compile.add_argument("--extra-args", nargs="*", default=None,
+		help="Extra arguments to pass to the engine")
+
+	# install
+	p_install = sub.add_parser("install", help="Install a TeX Live package")
+	p_install.add_argument("package", help="Package name to install")
+
+	# remove
+	p_remove = sub.add_parser("remove", help="Remove a TeX Live package")
+	p_remove.add_argument("package", help="Package name to remove")
+
+	# list
+	sub.add_parser("list", help="List installed packages")
+
+	# search
+	p_search = sub.add_parser("search", help="Search for packages")
+	p_search.add_argument("query", help="Search query")
+
+	# info
+	p_info = sub.add_parser("info", help="Show package information")
+	p_info.add_argument("package", help="Package name")
+
+	# update
+	p_update = sub.add_parser("update", help="Update packages")
+	p_update.add_argument("package", nargs="?", default="-all",
+		help="Package to update (default: all)")
+
+	# version
+	sub.add_parser("version", help="Show TinyTeX/TeX Live version")
+
+	# doctor
+	sub.add_parser("doctor", help="Check TinyTeX installation health")
+
+	# download
+	p_download = sub.add_parser("download", help="Download TinyTeX")
+	p_download.add_argument("--variation", type=int, default=1,
+		choices=[0, 1, 2], help="TinyTeX variation (default: 1)")
+	p_download.add_argument("--version", default="latest",
+		help="TinyTeX version (default: latest)")
+
+	# uninstall
+	p_uninstall = sub.add_parser("uninstall", help="Remove TinyTeX installation")
+	p_uninstall.add_argument("--path", default=None,
+		help="Path to TinyTeX installation to remove")
+
+	args = parser.parse_args(argv)
+
+	if not args.command:
+		parser.print_help()
+		return 1
+
+	import pytinytex
+
+	try:
+		if args.command == "compile":
+			result = pytinytex.compile(
+				args.file,
+				engine=args.engine,
+				output_dir=args.output_dir,
+				num_runs=args.runs,
+				auto_install=args.auto_install,
+				extra_args=args.extra_args,
+			)
+			if result.installed_packages:
+				print("Auto-installed packages: " + ", ".join(result.installed_packages))
+			if result.errors:
+				print("Errors:")
+				for entry in result.errors:
+					loc = ""
+					if entry.file:
+						loc += entry.file
+					if entry.line:
+						loc += ":" + str(entry.line)
+					if loc:
+						loc = " (" + loc + ")"
+					print("  ! " + entry.message + loc)
+			if result.warnings:
+				print("Warnings: %d" % len(result.warnings))
+			if result.success:
+				print("Success: " + str(result.pdf_path))
+			else:
+				print("Compilation failed.")
+				return 1
+
+		elif args.command == "install":
+			exit_code, output = pytinytex.install(args.package)
+			if output:
+				print(output)
+
+		elif args.command == "remove":
+			exit_code, output = pytinytex.remove(args.package)
+			if output:
+				print(output)
+
+		elif args.command == "list":
+			packages = pytinytex.list_installed()
+			for pkg in packages:
+				marker = "i" if pkg.get("installed") else " "
+				detail = pkg.get("detail", "")
+				print(" %s %s  %s" % (marker, pkg["name"], detail))
+
+		elif args.command == "search":
+			results = pytinytex.search(args.query)
+			for pkg in results:
+				desc = pkg.get("description", pkg.get("detail", ""))
+				print("  %s  %s" % (pkg["name"], desc))
+
+		elif args.command == "info":
+			info = pytinytex.info(args.package)
+			for key, value in info.items():
+				print("  %s: %s" % (key, value))
+
+		elif args.command == "update":
+			exit_code, output = pytinytex.update(args.package)
+			if output:
+				print(output)
+
+		elif args.command == "version":
+			print(pytinytex.get_version())
+
+		elif args.command == "doctor":
+			result = pytinytex.doctor()
+			for check in result.checks:
+				status = "PASS" if check.passed else "FAIL"
+				print("  [%s] %s: %s" % (status, check.name, check.message))
+			if result.healthy:
+				print("\nAll checks passed.")
+			else:
+				print("\nSome checks failed.")
+				return 1
+
+		elif args.command == "download":
+			def _progress(downloaded, total):
+				if total > 0:
+					pct = downloaded * 100 // total
+					mb_down = downloaded / (1024 * 1024)
+					mb_total = total / (1024 * 1024)
+					sys.stdout.write(
+						"\r  Downloading: %.1f/%.1f MB (%d%%)" % (mb_down, mb_total, pct)
+					)
+					sys.stdout.flush()
+
+			pytinytex.download_tinytex(
+				version=getattr(args, "version", "latest"),
+				variation=args.variation,
+				progress_callback=_progress,
+			)
+			print("\nDone.")
+
+		elif args.command == "uninstall":
+			pytinytex.uninstall(args.path)
+			print("TinyTeX uninstalled.")
+
+	except RuntimeError as e:
+		print("Error: %s" % e, file=sys.stderr)
+		return 1
+
+	return 0

--- a/pytinytex/compiler.py
+++ b/pytinytex/compiler.py
@@ -1,0 +1,205 @@
+"""LaTeX compilation with optional auto-install of missing packages."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .log_parser import LogEntry, ParsedLog, parse_log
+
+logger = logging.getLogger("pytinytex")
+
+
+@dataclasses.dataclass
+class CompileResult:
+	"""Result of a LaTeX compilation."""
+	success: bool
+	pdf_path: Optional[str] = None
+	log_path: Optional[str] = None
+	engine: str = "pdflatex"
+	runs: int = 0
+	errors: List[LogEntry] = dataclasses.field(default_factory=list)
+	warnings: List[LogEntry] = dataclasses.field(default_factory=list)
+	installed_packages: List[str] = dataclasses.field(default_factory=list)
+	output: str = ""
+
+
+def compile(
+	tex_file,
+	engine="pdflatex",
+	output_dir=None,
+	num_runs=1,
+	auto_install=False,
+	max_install_attempts=3,
+	extra_args=None,
+):
+	"""Compile a .tex file to PDF.
+
+	Args:
+		tex_file: Path to the .tex file to compile.
+		engine: LaTeX engine to use ('pdflatex', 'xelatex', 'lualatex',
+			'latex'). Defaults to 'pdflatex'.
+		output_dir: Directory for output files. Defaults to the same
+			directory as the .tex file.
+		num_runs: Number of compilation passes. Use 2+ for cross-references
+			and TOC. Defaults to 1.
+		auto_install: If True, automatically install missing packages via
+			tlmgr and retry compilation. Defaults to False.
+		max_install_attempts: Maximum number of install-and-retry cycles
+			when auto_install is True. Defaults to 3.
+		extra_args: Additional command-line arguments to pass to the engine.
+
+	Returns:
+		CompileResult with compilation outcome, parsed errors/warnings,
+		and list of any auto-installed packages.
+
+	Raises:
+		FileNotFoundError: If tex_file does not exist.
+		ValueError: If engine is not a known LaTeX engine.
+	"""
+	# Import here to avoid circular imports
+	from . import get_engine
+	from .tlmgr import install
+
+	tex_path = Path(tex_file).resolve()
+	if not tex_path.exists():
+		raise FileNotFoundError(f"TeX file not found: {tex_path}")
+
+	engine_path = get_engine(engine)
+
+	if output_dir is None:
+		output_dir = str(tex_path.parent)
+	else:
+		Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+	stem = tex_path.stem
+	pdf_path = os.path.join(output_dir, stem + ".pdf")
+	log_path = os.path.join(output_dir, stem + ".log")
+
+	result = CompileResult(
+		success=False,
+		pdf_path=pdf_path,
+		log_path=log_path,
+		engine=engine,
+	)
+
+	all_installed = []
+
+	for attempt in range(max_install_attempts + 1):
+		# Build the command
+		cmd = [engine_path, "-interaction=nonstopmode"]
+		if output_dir:
+			cmd.append(f"-output-directory={output_dir}")
+		if extra_args:
+			cmd.extend(extra_args)
+		cmd.append(str(tex_path))
+
+		# Run for num_runs passes
+		output_lines = []
+		exit_code = 0
+		creation_flag = 0x08000000 if sys.platform == "win32" else 0
+
+		for run in range(num_runs):
+			logger.debug("Compilation pass %d/%d: %s", run + 1, num_runs, cmd)
+			try:
+				proc = subprocess.run(
+					cmd,
+					capture_output=True,
+					creationflags=creation_flag,
+				)
+				stdout = proc.stdout.decode("utf-8", errors="replace")
+				stderr = proc.stderr.decode("utf-8", errors="replace")
+				output_lines.append(stdout)
+				if stderr:
+					output_lines.append(stderr)
+				exit_code = proc.returncode
+			except Exception as e:
+				output_lines.append(str(e))
+				exit_code = 1
+				break
+
+		result.runs = num_runs
+		result.output = "\n".join(output_lines)
+
+		# Parse the log file if it exists
+		parsed = ParsedLog()
+		if os.path.isfile(log_path):
+			try:
+				with open(log_path, encoding="utf-8", errors="replace") as f:
+					log_content = f.read()
+				parsed = parse_log(log_content)
+			except Exception as e:
+				logger.warning("Failed to parse log file: %s", e)
+
+		result.errors = parsed.errors
+		result.warnings = parsed.warnings
+		result.success = exit_code == 0 and os.path.isfile(pdf_path)
+
+		# Auto-install missing packages if needed
+		if (
+			auto_install
+			and parsed.missing_packages
+			and attempt < max_install_attempts
+		):
+			newly_installed = []
+			for pkg in parsed.missing_packages:
+				if pkg in all_installed:
+					continue
+				logger.info("Auto-installing missing package: %s", pkg)
+				try:
+					# Try to find the correct TeX Live package name
+					pkg_name = _resolve_package_name(pkg)
+					install(pkg_name)
+					newly_installed.append(pkg_name)
+					all_installed.append(pkg_name)
+				except RuntimeError as e:
+					logger.warning("Failed to install '%s': %s", pkg, e)
+
+			if not newly_installed:
+				# Nothing new could be installed, no point retrying
+				break
+
+			logger.info("Retrying compilation after installing: %s", newly_installed)
+			continue
+
+		# No auto-install needed or not enabled
+		break
+
+	result.installed_packages = all_installed
+	return result
+
+
+def _resolve_package_name(sty_name):
+	"""Try to resolve a .sty file name to a TeX Live package name.
+
+	For most packages, the .sty name matches the package name.
+	Falls back to the sty_name itself if tlmgr search fails.
+	"""
+	from . import get_tinytex_path
+	from .tlmgr import _run_tlmgr_command
+
+	try:
+		path = get_tinytex_path()
+		_, output = _run_tlmgr_command(
+			["search", "--file", sty_name + ".sty"],
+			path,
+			machine_readable=False,
+		)
+		# Parse tlmgr search output for package names
+		# Lines look like: "texmf-dist/tex/latex/booktabs/booktabs.sty"
+		# or "<package>:" header lines
+		for line in output.splitlines():
+			line = line.strip()
+			if line.endswith(":") and not line.startswith(" "):
+				# This is a package name header
+				return line.rstrip(":")
+	except RuntimeError:
+		pass
+
+	# Fallback: assume sty name == package name
+	return sty_name

--- a/pytinytex/doctor.py
+++ b/pytinytex/doctor.py
@@ -1,0 +1,75 @@
+"""TinyTeX installation health check."""
+
+import dataclasses
+import os
+import platform
+from typing import List
+
+
+@dataclasses.dataclass
+class DoctorCheck:
+	"""A single health check result."""
+	name: str
+	passed: bool
+	message: str
+
+@dataclasses.dataclass
+class DoctorResult:
+	"""Overall health check result."""
+	healthy: bool
+	checks: List[DoctorCheck] = dataclasses.field(default_factory=list)
+
+
+def doctor():
+	"""Check the health of the TinyTeX installation.
+
+	Returns:
+		DoctorResult with individual check outcomes.
+	"""
+	from . import get_tinytex_path, _LATEX_ENGINES, _find_file, _is_on_path
+	from .tlmgr import get_version
+
+	checks = []
+
+	# 1. TinyTeX installed?
+	try:
+		path = get_tinytex_path()
+		checks.append(DoctorCheck("TinyTeX installed", True, "Found at %s" % path))
+	except RuntimeError as e:
+		checks.append(DoctorCheck("TinyTeX installed", False, str(e)))
+		return DoctorResult(healthy=False, checks=checks)
+
+	# 2. TinyTeX on PATH?
+	if _is_on_path(path):
+		checks.append(DoctorCheck("PATH configured", True, "TinyTeX bin directory is on PATH"))
+	else:
+		checks.append(DoctorCheck("PATH configured", False,
+			"TinyTeX bin directory (%s) is not on PATH" % path))
+
+	# 3. tlmgr available?
+	tlmgr = _find_file(path, "tlmgr")
+	if tlmgr:
+		checks.append(DoctorCheck("tlmgr found", True, tlmgr))
+	else:
+		checks.append(DoctorCheck("tlmgr found", False, "tlmgr not found in %s" % path))
+
+	# 4. tlmgr functional?
+	if tlmgr:
+		try:
+			version = get_version()
+			checks.append(DoctorCheck("tlmgr functional", True, version.split("\n")[0]))
+		except RuntimeError as e:
+			checks.append(DoctorCheck("tlmgr functional", False, str(e)))
+
+	# 5. Engines available?
+	suffix = ".exe" if platform.system() == "Windows" else ""
+	for engine_name in _LATEX_ENGINES:
+		engine_path = os.path.join(path, engine_name + suffix)
+		if os.path.isfile(engine_path):
+			checks.append(DoctorCheck("Engine: %s" % engine_name, True, engine_path))
+		else:
+			checks.append(DoctorCheck("Engine: %s" % engine_name, False,
+				"Not found (requires TinyTeX variation >= 1)"))
+
+	healthy = all(c.passed for c in checks)
+	return DoctorResult(healthy=healthy, checks=checks)

--- a/pytinytex/log_parser.py
+++ b/pytinytex/log_parser.py
@@ -1,0 +1,141 @@
+"""LaTeX log file parser for structured error/warning extraction."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import List, Optional
+
+
+@dataclasses.dataclass
+class LogEntry:
+	"""A single error or warning from a LaTeX log file."""
+	level: str  # "error" or "warning"
+	message: str
+	file: Optional[str] = None
+	line: Optional[int] = None
+	package: Optional[str] = None  # e.g. missing .sty name
+
+
+@dataclasses.dataclass
+class ParsedLog:
+	"""Structured result of parsing a LaTeX log file."""
+	errors: List[LogEntry] = dataclasses.field(default_factory=list)
+	warnings: List[LogEntry] = dataclasses.field(default_factory=list)
+	missing_packages: List[str] = dataclasses.field(default_factory=list)
+
+
+# Patterns for extracting information from LaTeX logs
+_RE_MISSING_FILE = re.compile(
+	r"! LaTeX Error: File [`'](.+?\.sty)' not found",
+)
+_RE_MISSING_FILE_ALT = re.compile(
+	r"! LaTeX Error: File [`'](.+?\.\w+)' not found",
+)
+_RE_ERROR = re.compile(r"^! (.+)", re.MULTILINE)
+_RE_LINE_NUMBER = re.compile(r"^l\.(\d+)", re.MULTILINE)
+_RE_WARNING = re.compile(
+	r"((?:LaTeX|Package|Class)\s+(?:\w+\s+)?Warning:\s*.+?)(?:\n(?!\s)|$)",
+	re.MULTILINE,
+)
+_RE_FILE_CONTEXT = re.compile(r"\(([^\s()]+\.\w+)")
+_RE_UNDEFINED_CONTROL = re.compile(
+	r"! Undefined control sequence\.",
+)
+_RE_MISSING_PACKAGE_SUGGESTION = re.compile(
+	r"(?:perhaps|try)\s+installing\s+the\s+(\S+)\s+package",
+	re.IGNORECASE,
+)
+
+
+def parse_log(log_content: str) -> ParsedLog:
+	"""Parse LaTeX log content into structured data.
+
+	Args:
+		log_content: Raw text content of a LaTeX .log file.
+
+	Returns:
+		ParsedLog with errors, warnings, and missing packages extracted.
+	"""
+	result = ParsedLog()
+	seen_packages = set()
+
+	# Extract missing .sty files
+	for match in _RE_MISSING_FILE.finditer(log_content):
+		sty_name = match.group(1)
+		pkg_name = sty_name.rsplit(".", 1)[0]
+		if pkg_name not in seen_packages:
+			seen_packages.add(pkg_name)
+			result.missing_packages.append(pkg_name)
+
+	# Parse errors
+	lines = log_content.split("\n")
+	i = 0
+	while i < len(lines):
+		line = lines[i]
+
+		# Standard LaTeX error: starts with "!"
+		if line.startswith("! "):
+			error_msg = line[2:]
+
+			# Collect continuation lines (until blank line or l.NNN)
+			file_ctx = _find_file_context(lines, i)
+			line_num = None
+			j = i + 1
+			while j < len(lines):
+				if not lines[j].strip():
+					break
+				line_match = _RE_LINE_NUMBER.match(lines[j])
+				if line_match:
+					line_num = int(line_match.group(1))
+					break
+				if not lines[j].startswith("! "):
+					error_msg += " " + lines[j].strip()
+				j += 1
+
+			# Check if this is a missing file error
+			pkg = None
+			sty_match = _RE_MISSING_FILE.match(line)
+			if sty_match:
+				pkg = sty_match.group(1).rsplit(".", 1)[0]
+
+			result.errors.append(LogEntry(
+				level="error",
+				message=error_msg.strip(),
+				file=file_ctx,
+				line=line_num,
+				package=pkg,
+			))
+			i = j + 1
+			continue
+
+		# Warnings
+		if "Warning:" in line:
+			warning_msg = line.strip()
+			# Collect continuation lines (indented)
+			j = i + 1
+			while j < len(lines) and lines[j].startswith(" "):
+				warning_msg += " " + lines[j].strip()
+				j += 1
+
+			file_ctx = _find_file_context(lines, i)
+			result.warnings.append(LogEntry(
+				level="warning",
+				message=warning_msg,
+				file=file_ctx,
+			))
+			i = j
+			continue
+
+		i += 1
+
+	return result
+
+
+def _find_file_context(lines: list, index: int) -> Optional[str]:
+	"""Walk backwards from index to find the most recent file context."""
+	for i in range(index, -1, -1):
+		match = _RE_FILE_CONTEXT.search(lines[i])
+		if match:
+			return match.group(1)
+	return None

--- a/pytinytex/tinytex_download.py
+++ b/pytinytex/tinytex_download.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import platform
 import re
 import shutil
@@ -90,12 +89,9 @@ def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET
 		tinytex_extracted = tmpdirname / extracted_dir_name
 		logger.info("Copying TinyTeX to %s...", target_folder)
 		shutil.copytree(tinytex_extracted, target_folder, dirs_exist_ok=True)
-	# Resolve the bin directory and add it to the OS PATH for this process
-	folder_to_add_to_path = target_folder / "bin"
-	while len(list(folder_to_add_to_path.glob("*"))) == 1 and folder_to_add_to_path.is_dir():
-		folder_to_add_to_path = list(folder_to_add_to_path.glob("*"))[0]
-	logger.info("Adding TinyTeX to PATH (%s)...", folder_to_add_to_path)
-	os.environ["PATH"] = str(folder_to_add_to_path) + os.pathsep + os.environ.get("PATH", "")
+	# Resolve the path and add to PATH so everything is ready to use
+	from . import ensure_tinytex_installed
+	ensure_tinytex_installed(target_folder)
 	logger.info("Done")
 
 def _get_tinytex_urls(version, variation):

--- a/pytinytex/tinytex_download.py
+++ b/pytinytex/tinytex_download.py
@@ -18,6 +18,17 @@ def _is_arm64():
 	"""Return True if running on an ARM64/aarch64 machine."""
 	return platform.machine().lower() in ("aarch64", "arm64")
 
+def _default_progress(downloaded, total):
+	"""Print download progress on a TTY."""
+	if total > 0:
+		pct = downloaded * 100 // total
+		mb = downloaded / (1024 * 1024)
+		mb_total = total / (1024 * 1024)
+		sys.stdout.write("\rDownloading TinyTeX: %.1f/%.1f MB (%d%%)" % (mb, mb_total, pct))
+		sys.stdout.flush()
+		if downloaded >= total:
+			sys.stdout.write("\n")
+
 def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET_FOLDER, download_folder=None, progress_callback=None):
 	if variation not in [0, 1, 2]:
 		raise RuntimeError(
@@ -32,6 +43,8 @@ def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET
 			"'latest' for the latest available version, or year.month, for example: "
 			"'2024.12', '2024.09' for a specific version.".format(version)
 		)
+	if progress_callback is None and sys.stdout.isatty():
+		progress_callback = _default_progress
 	variation = str(variation)
 	pf = sys.platform
 	if pf.startswith("linux"):

--- a/pytinytex/tinytex_download.py
+++ b/pytinytex/tinytex_download.py
@@ -19,7 +19,7 @@ def _is_arm64():
 	"""Return True if running on an ARM64/aarch64 machine."""
 	return platform.machine().lower() in ("aarch64", "arm64")
 
-def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET_FOLDER, download_folder=None):
+def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET_FOLDER, download_folder=None, progress_callback=None):
 	if variation not in [0, 1, 2]:
 		raise RuntimeError(
 			"Invalid TinyTeX variation {}. Valid variations are 0, 1, 2.".format(variation)
@@ -60,8 +60,17 @@ def download_tinytex(version="latest", variation=1, target_folder=DEFAULT_TARGET
 	else:
 		logger.info("* Downloading TinyTeX from %s ...", url)
 		response = urlopen(url)
+		total_size = int(response.headers.get("Content-Length", 0))
 		with open(filename, 'wb') as out_file:
-			shutil.copyfileobj(response, out_file)
+			downloaded = 0
+			while True:
+				chunk = response.read(8192)
+				if not chunk:
+					break
+				out_file.write(chunk)
+				downloaded += len(chunk)
+				if progress_callback:
+					progress_callback(downloaded, total_size)
 		logger.info("* Downloaded TinyTeX, saved in %s ...", filename)
 
 	logger.info("Extracting %s to a temporary folder...", filename)

--- a/pytinytex/tlmgr.py
+++ b/pytinytex/tlmgr.py
@@ -1,0 +1,311 @@
+"""TeX Live Manager (tlmgr) wrapper functions and command runner."""
+
+import asyncio
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("pytinytex")
+
+
+# --- Package management ---
+
+def install(package):
+	"""Install a TeX Live package via tlmgr.
+
+	Args:
+		package: Package name (e.g. "booktabs", "amsmath").
+
+	Returns:
+		Tuple of (exit_code, output).
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	return _run_tlmgr_command(["install", package], path, False)
+
+def remove(package):
+	"""Remove a TeX Live package via tlmgr.
+
+	Args:
+		package: Package name to remove.
+
+	Returns:
+		Tuple of (exit_code, output).
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	return _run_tlmgr_command(["remove", package], path, False)
+
+def list_installed():
+	"""List all installed TeX Live packages.
+
+	Returns:
+		List of dicts with keys such as 'name', 'installed', 'detail'.
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	_, output = _run_tlmgr_command(["list", "--only-installed"], path, True)
+	return _parse_tlmgr_list(output)
+
+def search(query):
+	"""Search for TeX Live packages matching a query.
+
+	Args:
+		query: Search term (package name or keyword).
+
+	Returns:
+		List of dicts with keys such as 'name', 'description'.
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	_, output = _run_tlmgr_command(["search", query], path, True)
+	return _parse_tlmgr_list(output)
+
+def info(package):
+	"""Get detailed information about a TeX Live package.
+
+	Args:
+		package: Package name.
+
+	Returns:
+		Dict with package metadata (keys vary by package, but typically
+		include 'package', 'revision', 'cat-version', 'category',
+		'shortdesc', 'longdesc', 'installed', 'sizes', etc.).
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	_, output = _run_tlmgr_command(["info", package], path, True)
+	return _parse_tlmgr_info(output)
+
+def update(package="-all"):
+	"""Update TeX Live packages via tlmgr.
+
+	Args:
+		package: Package name to update, or "-all" (default) to update
+			everything.
+
+	Returns:
+		Tuple of (exit_code, output).
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	return _run_tlmgr_command(["update", package], path, False)
+
+def help():
+	"""Display tlmgr help text.
+
+	Returns:
+		Tuple of (exit_code, output).
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	return _run_tlmgr_command(["help"], path, False)
+
+def shell():
+	"""Open an interactive tlmgr shell session."""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	return _run_tlmgr_command(["shell"], path, False, True)
+
+def get_version():
+	"""Return the installed TeX Live / TinyTeX version string.
+
+	Returns:
+		Version string as reported by ``tlmgr --version``.
+	"""
+	from . import get_tinytex_path
+	path = get_tinytex_path()
+	_, output = _run_tlmgr_command(["--version"], path, False)
+	return output.strip()
+
+def uninstall(path=None):
+	"""Remove the TinyTeX installation from disk and clear the path cache.
+
+	Args:
+		path: Directory to remove.  Defaults to the currently resolved
+			TinyTeX path (or DEFAULT_TARGET_FOLDER).
+	"""
+	from . import _tinytex_path, clear_path_cache
+	from .tinytex_download import DEFAULT_TARGET_FOLDER
+
+	if not path:
+		path = _tinytex_path() or str(DEFAULT_TARGET_FOLDER)
+	# Walk up from the bin directory to the installation root.
+	# The cached path typically points at e.g. .pytinytex/bin/x86_64-linux,
+	# but the user likely means the top-level .pytinytex folder.
+	target = Path(path)
+	default = Path(DEFAULT_TARGET_FOLDER)
+	try:
+		is_under_default = default.exists() and target.is_relative_to(default)
+	except AttributeError:
+		# Path.is_relative_to() was added in Python 3.9
+		try:
+			target.relative_to(default)
+			is_under_default = default.exists()
+		except ValueError:
+			is_under_default = False
+	if is_under_default:
+		target = default
+	if target.exists():
+		shutil.rmtree(target)
+		logger.info("Removed TinyTeX installation at %s", target)
+	clear_path_cache()
+
+
+# --- Machine-readable output parsing ---
+
+def _parse_tlmgr_list(output):
+	"""Parse tlmgr list/search machine-readable output into structured data.
+
+	Machine-readable list lines look like:
+		i collection-basic: 1 file, 4k
+	or plain lines like:
+		package_name - short description
+
+	Returns a list of dicts.
+	"""
+	results = []
+	for line in output.splitlines():
+		line = line.strip()
+		if not line:
+			continue
+		if ":" in line:
+			# e.g. "i collection-basic: 12345 1 file, 4k"
+			parts = line.split(":", 1)
+			left = parts[0].strip()
+			right = parts[1].strip() if len(parts) > 1 else ""
+			installed = left.startswith("i")
+			name = left.lstrip("i").strip()
+			results.append({
+				"name": name,
+				"installed": installed,
+				"detail": right,
+			})
+		elif " - " in line:
+			name, desc = line.split(" - ", 1)
+			results.append({
+				"name": name.strip(),
+				"description": desc.strip(),
+			})
+		else:
+			results.append({"name": line})
+	return results
+
+def _parse_tlmgr_info(output):
+	"""Parse tlmgr info machine-readable output into a dict.
+
+	Info output is typically key-value pairs like:
+		package:    booktabs
+		revision:   12345
+		shortdesc:  Publication quality tables
+	Multi-line values (like longdesc) are continued with leading whitespace.
+	"""
+	info = {}
+	current_key = None
+	for line in output.splitlines():
+		if not line.strip():
+			continue
+		if ":" in line and not line[0].isspace():
+			key, _, value = line.partition(":")
+			key = key.strip().lower()
+			value = value.strip()
+			info[key] = value
+			current_key = key
+		elif current_key and line[0].isspace():
+			info[current_key] += " " + line.strip()
+	return info
+
+
+# --- Command runner ---
+
+def _run_tlmgr_command(args, path, machine_readable=True, interactive=False):
+	from . import _find_file
+	if machine_readable:
+		if "--machine-readable" not in args:
+			args.insert(0, "--machine-readable")
+	tlmgr_executable = _find_file(path, "tlmgr")
+	if not tlmgr_executable:
+		raise RuntimeError(f"Unable to find tlmgr in {path}")
+	# resolve any symlinks
+	tlmgr_executable = str(Path(tlmgr_executable).resolve(True))
+	args.insert(0, tlmgr_executable)
+	new_env = os.environ.copy()
+	creation_flag = 0x08000000 if sys.platform == "win32" else 0
+
+	logger.debug("Running command: %s", args)
+	return asyncio.run(
+		_run_command(*args, stdin=interactive, env=new_env, creationflags=creation_flag)
+	)
+
+
+async def _read_stdout(process, output_buffer):
+	"""Read lines from process.stdout and collect them."""
+	logger.debug("Reading stdout from process %s", process.pid)
+	try:
+		while True:
+			line = await process.stdout.readline()
+			if not line:
+				break
+			line = line.decode('utf-8', errors='replace').rstrip()
+			output_buffer.append(line)
+			logger.info(line)
+	except Exception as e:
+		logger.error("Error in _read_stdout: %s", e)
+	finally:
+		process._transport.close()
+	return await process.wait()
+
+async def _send_stdin(process):
+	"""Read user input from sys.stdin and forward it to the process."""
+	logger.debug("Sending stdin to process %s", process.pid)
+	loop = asyncio.get_running_loop()
+	try:
+		while True:
+			user_input = await loop.run_in_executor(None, sys.stdin.readline)
+			if not user_input:
+				break
+			process.stdin.write(user_input.encode('utf-8'))
+			await process.stdin.drain()
+	except Exception as e:
+		logger.error("Error in _send_stdin: %s", e)
+	finally:
+		if process.stdin:
+			process._transport.close()
+
+
+async def _run_command(*args, stdin=False, **kwargs):
+	process = await asyncio.create_subprocess_exec(
+		*args,
+		stdout=asyncio.subprocess.PIPE,
+		stderr=asyncio.subprocess.STDOUT,
+		stdin=asyncio.subprocess.PIPE if stdin else asyncio.subprocess.DEVNULL,
+		**kwargs
+	)
+
+	output_buffer = []
+	stdout_task = asyncio.create_task(_read_stdout(process, output_buffer))
+	stdin_task = None
+	if stdin:
+		stdin_task = asyncio.create_task(_send_stdin(process))
+
+	try:
+		if stdin:
+			logger.debug("Waiting for stdout and stdin tasks to complete")
+			await asyncio.gather(stdout_task, stdin_task)
+		else:
+			logger.debug("Waiting for stdout task to complete")
+			await stdout_task
+		exit_code = await process.wait()
+	except KeyboardInterrupt:
+		process.terminate()
+		exit_code = await process.wait()
+	finally:
+		stdout_task.cancel()
+		if stdin_task:
+			stdin_task.cancel()
+	captured_output = "\n".join(output_buffer)
+	if exit_code != 0:
+		raise RuntimeError(f"Error running command: {captured_output}")
+	return exit_code, captured_output

--- a/readme.md
+++ b/readme.md
@@ -6,63 +6,115 @@
 [![Python version](https://img.shields.io/pypi/pyversions/PyTinyTeX.svg)](https://pypi.python.org/pypi/PyTinyTeX/)
 ![License](https://img.shields.io/pypi/l/PyTinyTeX.svg)
 
-PyTinyTeX provides a thin wrapper for [TinyTeX](https://yihui.org/tinytex), A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live.
+The easiest way to go from `.tex` to `.pdf` in Python. PyTinyTeX wraps [TinyTeX](https://yihui.org/tinytex) — a lightweight, cross-platform, portable LaTeX distribution based on TeX Live — and gives you compilation, package management, and diagnostics from Python or the command line.
 
-### Installation
+```python
+import pytinytex
 
-Installation through the normal means
+pytinytex.download_tinytex()
+result = pytinytex.compile("paper.tex", auto_install=True)
+print(result.pdf_path)  # paper.pdf
+```
+
+No system-wide TeX installation required. Missing packages are installed automatically.
+
+---
+
+## Installation
 
 ```
 pip install pytinytex
 ```
 
-### Installing a version of TinyTeX
+Python 3.8+ on Linux, macOS, and Windows.
 
-Each version of TinyTeX contains three variations:
-* TinyTeX-0.* contains the infraonly scheme of TeX Live, without any LaTeX packages.
-* TinyTeX-1.* contains about 90 LaTeX packages enough to compile common R Markdown documents (which was the original motivation of the TinyTeX project).
-* TinyTeX-2-* contains more LaTeX packages requested by the community. The list of packages may grow as time goes by, and the size of this variation will grow correspondingly.
+## Quick start
 
-
-By default the variation PyTinyTeX will install is variation 1, but this can be changed.
+### 1. Get TinyTeX
 
 ```python
 import pytinytex
 
-pytinytex.download_tinytex(variation=0)
+# Download the default variation (variation 1: ~90 common LaTeX packages)
+pytinytex.download_tinytex()
+
+# Or pick a variation:
+#   0 — infrastructure only, no packages
+#   1 — common packages (default)
+#   2 — extended package set
+pytinytex.download_tinytex(variation=2)
+
+# Track download progress
+pytinytex.download_tinytex(progress_callback=lambda downloaded, total: print(f"{downloaded}/{total} bytes"))
 ```
 
-You can also use `ensure_tinytex_installed()` which will automatically download TinyTeX if it is not already installed:
+### 2. Compile a document
 
 ```python
-import pytinytex
+result = pytinytex.compile("paper.tex")
 
-# Downloads TinyTeX automatically if not found
-pytinytex.ensure_tinytex_installed()
+if result.success:
+    print("PDF at:", result.pdf_path)
+else:
+    for error in result.errors:
+        print(f"  ! {error.message} (line {error.line})")
 ```
 
-
-### Getting the TinyTeX path
-
-After installing TinyTeX, you can get the path to the installed distribution with the following:
+Multi-pass compilation for cross-references and TOC:
 
 ```python
-import pytinytex
-
-pytinytex.get_tinytex_path()
-# /home/jessica/.pytinytex/
-# c:\Users\Jessica\.pytinytex\
+result = pytinytex.compile("paper.tex", num_runs=2)
 ```
 
-### LaTeX engine discovery
+Choose your engine:
 
-PyTinyTeX can locate LaTeX engine executables included with TinyTeX (variation 1 and above):
+```python
+result = pytinytex.compile("paper.tex", engine="xelatex")
+result = pytinytex.compile("paper.tex", engine="lualatex")
+```
+
+### 3. Auto-install missing packages
+
+The killer feature: if your document needs a package you don't have, PyTinyTeX can find it, install it, and retry — all in one call:
+
+```python
+result = pytinytex.compile("paper.tex", auto_install=True)
+print(result.installed_packages)  # e.g. ['booktabs', 'pgf']
+```
+
+## Package management
+
+Full access to the TeX Live package manager (tlmgr):
 
 ```python
 import pytinytex
 
-# Generic — pass any engine name
-pytinytex.get_engine("pdflatex")
+pytinytex.install("booktabs")
+pytinytex.remove("booktabs")
+
+# List installed packages (returns list of dicts)
+for pkg in pytinytex.list_installed():
+    print(pkg["name"])
+
+# Search for packages
+pytinytex.search("amsmath")
+
+# Detailed package info (returns dict)
+pytinytex.info("booktabs")
+
+# Update all packages
+pytinytex.update()
+
+# TeX Live version
+pytinytex.get_version()
+```
+
+## Engine discovery
+
+Locate LaTeX engine executables (variation 1+):
+
+```python
+pytinytex.get_engine("pdflatex")   # full path to the executable
 pytinytex.get_engine("xelatex")
 pytinytex.get_engine("lualatex")
 
@@ -72,66 +124,105 @@ pytinytex.get_xelatex_engine()
 pytinytex.get_lualatex_engine()
 ```
 
-### Package management
+## LaTeX log parser
 
-PyTinyTeX wraps the tlmgr (TeX Live Manager) interface for managing LaTeX packages:
+Parse any LaTeX `.log` file into structured data — useful even outside PyTinyTeX:
 
 ```python
-import pytinytex
+from pytinytex import parse_log
 
-# Install / remove packages
-pytinytex.install("booktabs")
-pytinytex.remove("booktabs")
+with open("paper.log") as f:
+    parsed = parse_log(f.read())
 
-# List installed packages (returns list of dicts)
-pytinytex.list_installed()
+for error in parsed.errors:
+    print(f"{error.file}:{error.line}: {error.message}")
 
-# Search for packages
-pytinytex.search("amsmath")
+for warning in parsed.warnings:
+    print(warning.message)
 
-# Get detailed info about a package (returns dict)
-pytinytex.info("booktabs")
-
-# Update all packages
-pytinytex.update()
-
-# Get the TeX Live version string
-pytinytex.get_version()
+# Missing .sty packages detected automatically
+print(parsed.missing_packages)  # e.g. ['tikz', 'booktabs']
 ```
 
-### Integrating  with pypandoc
+## Health check
 
-PyTinyTeX can be used with [PyPandoc](https://pypi.org/project/pypandoc/), a Python wrapper for Pandoc. PyPandoc can be used to convert documents between different formats, including LaTeX to PDF.
-To use PyTinyTeX with pypandoc, when working with latex or pdf documents, you need to give pypandoc the path to pdflatex (included with variation 1 and above), like the following:
+Diagnose your TinyTeX installation:
+
+```python
+result = pytinytex.doctor()
+for check in result.checks:
+    status = "PASS" if check.passed else "FAIL"
+    print(f"  [{status}] {check.name}: {check.message}")
+```
+
+Checks: TinyTeX installed, PATH configured, tlmgr functional, engine availability.
+
+## Command-line interface
+
+Every feature is also available from the terminal:
+
+```bash
+# Download TinyTeX
+pytinytex download
+pytinytex download --variation 2
+
+# Compile a document
+pytinytex compile paper.tex
+pytinytex compile paper.tex --engine xelatex --runs 2 --auto-install
+
+# Package management
+pytinytex install booktabs
+pytinytex remove booktabs
+pytinytex list
+pytinytex search amsmath
+pytinytex info booktabs
+pytinytex update
+
+# Diagnostics
+pytinytex doctor
+pytinytex version
+
+# Also works as a Python module
+python -m pytinytex doctor
+```
+
+## Integrating with pypandoc
+
+PyTinyTeX pairs naturally with [pypandoc](https://pypi.org/project/pypandoc/) for converting Markdown, HTML, and other formats to PDF:
 
 ```python
 import pytinytex
 import pypandoc
 
-# make sure that pytinytex is installed
-pytinytex.ensure_tinytex_installed()
-
-# get the path to the pdflatex executable
 pdflatex_path = pytinytex.get_pdflatex_engine()
-
-# convert a markdown file to a pdf
-pypandoc.convert_file('input.md', 'pdf', outputfile='output.pdf', extra_args=['--pdf-engine', pdflatex_path])
+pypandoc.convert_file("input.md", "pdf", outputfile="output.pdf",
+                      extra_args=["--pdf-engine", pdflatex_path])
 ```
 
+## Uninstalling TinyTeX
 
-### Contributing
+```python
+pytinytex.uninstall()  # removes the TinyTeX directory
+```
+
+Or from the CLI:
+
+```bash
+pytinytex uninstall
+```
+
+## Contributing
 
 Contributions are welcome. When opening a PR, please keep the following guidelines in mind:
 
 1. Before implementing, please open an issue for discussion.
 2. Make sure you have tests for the new logic.
-3. Add yourself to contributors at README.md unless you are already there. In that case tweak your
+3. Add yourself to contributors in this README unless you are already there.
 
+## Contributors
 
-### Contributors
+* [Jessica Tegner](https://github.com/JessicaTegner) — Maintainer and original creator of PyTinyTeX
 
-* [Jessica Tegner](https://github.com/JessicaTegner) - Maintainer and original creator of PyTinyTeX
+## License
 
-### License
-
-PyTinyTeX is available under MIT license. See [LICENSE](https://raw.githubusercontent.com/JessicaTegner/PyTinyTeX/master/LICENSE) for more details. TinyTeX itself is available under the GPL-2 license.
+PyTinyTeX is available under the MIT license. See [LICENSE](https://raw.githubusercontent.com/JessicaTegner/PyTinyTeX/master/LICENSE) for more details. TinyTeX itself is available under the GPL-2 license.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+"""Tests for the CLI module."""
+
+from pytinytex.cli import main
+
+
+def test_cli_no_args():
+	"""Running with no args should print help and return 1."""
+	result = main([])
+	assert result == 1
+
+
+def test_cli_version(monkeypatch):
+	"""Test the version subcommand."""
+	monkeypatch.setattr("pytinytex.get_version", lambda: "tlmgr revision 12345")
+	result = main(["version"])
+	assert result == 0
+
+
+def test_cli_help_flag(capsys):
+	"""--help should work without errors."""
+	try:
+		main(["--help"])
+	except SystemExit:
+		pass  # argparse calls sys.exit(0) on --help

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -122,3 +122,109 @@ def test_compile_result_fields():
 	assert result.installed_packages == []
 	assert result.output == ""
 	assert result.pdf_path is None
+
+
+# --- End-to-end tests ---
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_end_to_end_produces_valid_pdf(download_tinytex, simple_tex):  # noqa
+	"""Verify compile produces a real PDF file with valid header."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(simple_tex)
+	assert result.success is True
+	assert os.path.isfile(result.pdf_path)
+	# Check the file starts with the PDF magic bytes
+	with open(result.pdf_path, "rb") as f:
+		header = f.read(5)
+	assert header == b"%PDF-", "Output file is not a valid PDF"
+	# Log file should also exist
+	assert os.path.isfile(result.log_path)
+	# No errors expected for a simple document
+	assert len(result.errors) == 0
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_end_to_end_with_cross_references(download_tinytex):  # noqa
+	"""Verify multi-pass resolves cross-references."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "crossref.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\begin{document}
+See Section~\ref{sec:hello}.
+\section{Hello}\label{sec:hello}
+This is the section.
+\end{document}
+""")
+		# Single pass: may have unresolved references
+		result_single = pytinytex.compile(tex_path, num_runs=1)
+		assert result_single.success is True
+
+		# Two passes: references should be resolved
+		result_double = pytinytex.compile(tex_path, num_runs=2)
+		assert result_double.success is True
+		assert result_double.runs == 2
+		assert os.path.isfile(result_double.pdf_path)
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_end_to_end_xelatex(download_tinytex, simple_tex):  # noqa
+	"""Verify compilation works with xelatex engine."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(simple_tex, engine="xelatex")
+	assert result.success is True
+	assert result.engine == "xelatex"
+	assert os.path.isfile(result.pdf_path)
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_auto_install_missing_package(download_tinytex):  # noqa
+	"""Verify auto_install=True finds, installs, and retries for a missing package."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+
+	# First, make sure blindtext is NOT installed
+	try:
+		pytinytex.remove("blindtext")
+	except RuntimeError:
+		pass  # already not installed
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "autoinstall.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\usepackage{blindtext}
+\begin{document}
+\blindtext
+\end{document}
+""")
+		result = pytinytex.compile(tex_path, auto_install=True)
+		assert result.success is True
+		assert os.path.isfile(result.pdf_path)
+		assert len(result.installed_packages) > 0
+		assert any("blindtext" in pkg for pkg in result.installed_packages)
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_auto_install_false_does_not_install(download_tinytex):  # noqa
+	"""Verify auto_install=False does not install missing packages."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+
+	# Remove blindtext if present
+	try:
+		pytinytex.remove("blindtext")
+	except RuntimeError:
+		pass
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "noauto.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\usepackage{blindtext}
+\begin{document}
+\blindtext
+\end{document}
+""")
+		result = pytinytex.compile(tex_path, auto_install=False)
+		assert result.success is False
+		assert len(result.installed_packages) == 0

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -9,6 +9,14 @@ import pytinytex
 from .utils import download_tinytex, TINYTEX_DISTRIBUTION  # noqa
 
 
+def _self_update_tlmgr():
+	"""Update tlmgr itself so it doesn't refuse to run other commands."""
+	try:
+		pytinytex.update("--self")
+	except RuntimeError:
+		pass  # best-effort; may fail if already up to date or no network
+
+
 @pytest.fixture
 def simple_tex():
 	"""Create a simple .tex file in a temp directory."""
@@ -182,6 +190,7 @@ def test_compile_end_to_end_xelatex(download_tinytex, simple_tex):  # noqa
 def test_compile_auto_install_missing_package(download_tinytex):  # noqa
 	"""Verify auto_install=True finds, installs, and retries for a missing package."""
 	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	_self_update_tlmgr()
 
 	# First, make sure blindtext is NOT installed
 	try:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,124 @@
+"""Tests for the compile() function."""
+
+import os
+import tempfile
+
+import pytest
+
+import pytinytex
+from .utils import download_tinytex, TINYTEX_DISTRIBUTION  # noqa
+
+
+@pytest.fixture
+def simple_tex():
+	"""Create a simple .tex file in a temp directory."""
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "test.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\begin{document}
+Hello, World!
+\end{document}
+""")
+		yield tex_path
+
+
+@pytest.fixture
+def bad_tex():
+	"""Create a .tex file with errors."""
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "bad.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\begin{document}
+\badcommand
+\end{document}
+""")
+		yield tex_path
+
+
+@pytest.fixture
+def missing_pkg_tex():
+	"""Create a .tex file that requires a missing package."""
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "missing.tex")
+		with open(tex_path, "w") as f:
+			f.write(r"""\documentclass{article}
+\usepackage{nonexistent_pkg_xyz_123}
+\begin{document}
+Hello
+\end{document}
+""")
+		yield tex_path
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_simple(download_tinytex, simple_tex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(simple_tex)
+	assert isinstance(result, pytinytex.CompileResult)
+	assert result.success is True
+	assert result.pdf_path is not None
+	assert os.path.isfile(result.pdf_path)
+	assert result.engine == "pdflatex"
+	assert result.runs == 1
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_multi_run(download_tinytex, simple_tex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(simple_tex, num_runs=2)
+	assert result.success is True
+	assert result.runs == 2
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_output_dir(download_tinytex, simple_tex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	with tempfile.TemporaryDirectory() as outdir:
+		result = pytinytex.compile(simple_tex, output_dir=outdir)
+		assert result.success is True
+		assert outdir in result.pdf_path
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_with_errors(download_tinytex, bad_tex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(bad_tex)
+	# pdflatex in nonstopmode may still produce a PDF despite errors
+	assert isinstance(result, pytinytex.CompileResult)
+	assert result.log_path is not None
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_compile_missing_package(download_tinytex, missing_pkg_tex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.compile(missing_pkg_tex, auto_install=False)
+	# Should fail due to missing package
+	assert result.success is False
+
+
+def test_compile_nonexistent_file():
+	with pytest.raises(FileNotFoundError):
+		pytinytex.compile("/nonexistent/path/file.tex")
+
+
+def test_compile_invalid_engine():
+	with tempfile.TemporaryDirectory() as tmpdir:
+		tex_path = os.path.join(tmpdir, "test.tex")
+		with open(tex_path, "w") as f:
+			f.write("\\documentclass{article}\\begin{document}Hi\\end{document}")
+		with pytest.raises(ValueError):
+			pytinytex.compile(tex_path, engine="badengine")
+
+
+def test_compile_result_fields():
+	result = pytinytex.CompileResult(success=True, engine="xelatex", runs=2)
+	assert result.success is True
+	assert result.engine == "xelatex"
+	assert result.runs == 2
+	assert result.errors == []
+	assert result.warnings == []
+	assert result.installed_packages == []
+	assert result.output == ""
+	assert result.pdf_path is None

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -45,3 +45,68 @@ def test_doctor_engines_present(download_tinytex):  # noqa
 	)
 	if pdflatex_check:
 		assert pdflatex_check.passed is True
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_doctor_reports_healthy(download_tinytex):  # noqa
+	"""Variation 1 should report a fully healthy installation."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	# All non-engine checks should pass
+	core_checks = [c for c in result.checks if not c.name.startswith("Engine:")]
+	for check in core_checks:
+		assert check.passed is True, "Check '%s' failed: %s" % (check.name, check.message)
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_doctor_path_on_path(download_tinytex):  # noqa
+	"""After ensure_tinytex_installed, PATH check should pass."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	path_check = next(c for c in result.checks if c.name == "PATH configured")
+	assert path_check.passed is True
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_doctor_tlmgr_functional(download_tinytex):  # noqa
+	"""tlmgr should be able to report its version."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	func_check = next(c for c in result.checks if c.name == "tlmgr functional")
+	assert func_check.passed is True
+	assert len(func_check.message) > 0
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_doctor_consistent_across_runs(download_tinytex):  # noqa
+	"""Doctor should return the same results on consecutive runs."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result1 = pytinytex.doctor()
+	result2 = pytinytex.doctor()
+	assert result1.healthy == result2.healthy
+	assert len(result1.checks) == len(result2.checks)
+	for c1, c2 in zip(result1.checks, result2.checks):
+		assert c1.name == c2.name
+		assert c1.passed == c2.passed
+
+
+def test_doctor_without_tinytex():
+	"""Doctor should report unhealthy when TinyTeX is not installed."""
+	pytinytex.clear_path_cache()
+	# Point to a nonexistent path
+	import os
+	old_env = os.environ.get("PYTINYTEX_TINYTEX")
+	os.environ["PYTINYTEX_TINYTEX"] = "/nonexistent/path/tinytex"
+	try:
+		result = pytinytex.doctor()
+		assert result.healthy is False
+		assert len(result.checks) >= 1
+		install_check = result.checks[0]
+		assert install_check.name == "TinyTeX installed"
+		assert install_check.passed is False
+	finally:
+		if old_env is not None:
+			os.environ["PYTINYTEX_TINYTEX"] = old_env
+		else:
+			os.environ.pop("PYTINYTEX_TINYTEX", None)
+		pytinytex.clear_path_cache()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,47 @@
+"""Tests for the doctor() health check."""
+
+import pytest
+
+import pytinytex
+from .utils import download_tinytex, TINYTEX_DISTRIBUTION  # noqa
+
+
+def test_doctor_result_structure(download_tinytex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	assert isinstance(result, pytinytex.DoctorResult)
+	assert isinstance(result.checks, list)
+	assert len(result.checks) > 0
+	for check in result.checks:
+		assert isinstance(check, pytinytex.DoctorCheck)
+		assert isinstance(check.name, str)
+		assert isinstance(check.passed, bool)
+		assert isinstance(check.message, str)
+
+
+def test_doctor_tinytex_installed(download_tinytex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	install_check = next(c for c in result.checks if c.name == "TinyTeX installed")
+	assert install_check.passed is True
+
+
+def test_doctor_tlmgr_found(download_tinytex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	tlmgr_check = next(c for c in result.checks if c.name == "tlmgr found")
+	assert tlmgr_check.passed is True
+
+
+@pytest.mark.parametrize("download_tinytex", [1], indirect=True)
+def test_doctor_engines_present(download_tinytex):  # noqa
+	"""Variation 1 should have pdflatex at minimum."""
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
+	result = pytinytex.doctor()
+	engine_checks = [c for c in result.checks if c.name.startswith("Engine:")]
+	assert len(engine_checks) > 0
+	pdflatex_check = next(
+		(c for c in engine_checks if "pdflatex" in c.name), None
+	)
+	if pdflatex_check:
+		assert pdflatex_check.passed is True

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,143 @@
+"""Tests for the LaTeX log parser."""
+
+from pytinytex.log_parser import parse_log, LogEntry, ParsedLog
+
+
+def test_parse_empty_log():
+	result = parse_log("")
+	assert isinstance(result, ParsedLog)
+	assert result.errors == []
+	assert result.warnings == []
+	assert result.missing_packages == []
+
+
+def test_parse_missing_sty():
+	log = """\
+(/some/file.tex
+! LaTeX Error: File `booktabs.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name:
+"""
+	result = parse_log(log)
+	assert len(result.missing_packages) == 1
+	assert "booktabs" in result.missing_packages
+	assert len(result.errors) == 1
+	assert result.errors[0].package == "booktabs"
+
+
+def test_parse_multiple_missing_packages():
+	log = """\
+! LaTeX Error: File `foo.sty' not found.
+
+l.5 \\usepackage{foo}
+
+! LaTeX Error: File `bar.sty' not found.
+
+l.6 \\usepackage{bar}
+"""
+	result = parse_log(log)
+	assert len(result.missing_packages) == 2
+	assert "foo" in result.missing_packages
+	assert "bar" in result.missing_packages
+
+
+def test_parse_duplicate_missing_package():
+	log = """\
+! LaTeX Error: File `foo.sty' not found.
+
+! LaTeX Error: File `foo.sty' not found.
+"""
+	result = parse_log(log)
+	assert len(result.missing_packages) == 1
+	assert result.missing_packages[0] == "foo"
+
+
+def test_parse_error_with_line_number():
+	log = """\
+! Undefined control sequence.
+l.42 \\badcommand
+"""
+	result = parse_log(log)
+	assert len(result.errors) == 1
+	assert result.errors[0].line == 42
+	assert "Undefined control sequence" in result.errors[0].message
+
+
+def test_parse_warning():
+	log = """\
+LaTeX Warning: Reference `fig:test' on page 1 undefined on input line 10.
+"""
+	result = parse_log(log)
+	assert len(result.warnings) == 1
+	assert "Reference" in result.warnings[0].message
+	assert result.warnings[0].level == "warning"
+
+
+def test_parse_package_warning():
+	log = """\
+Package hyperref Warning: Token not allowed in a PDF string (Unicode):
+ removing `\\textbf' on input line 25.
+"""
+	result = parse_log(log)
+	assert len(result.warnings) == 1
+	assert "hyperref" in result.warnings[0].message
+
+
+def test_parse_complex_log():
+	"""Test parsing a realistic log with mixed content."""
+	log = """\
+This is pdfTeX, Version 3.14159265 (TeX Live 2024) (preloaded format=pdflatex)
+entering extended mode
+(/home/user/doc.tex
+LaTeX2e <2024-06-01> patch level 2
+(/usr/share/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2024/06/29 v1.4n Standard LaTeX document class
+)
+! LaTeX Error: File `tikz.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name:
+l.3 \\usepackage{tikz}
+
+LaTeX Warning: Label `eq:1' multiply defined.
+
+No pages of output.
+"""
+	result = parse_log(log)
+	assert len(result.missing_packages) == 1
+	assert "tikz" in result.missing_packages
+	assert len(result.errors) >= 1
+	assert len(result.warnings) >= 1
+
+
+def test_parse_no_errors_success():
+	log = """\
+This is pdfTeX, Version 3.14159265 (TeX Live 2024)
+entering extended mode
+Output written on test.pdf (1 page, 1234 bytes).
+Transcript written on test.log.
+"""
+	result = parse_log(log)
+	assert len(result.errors) == 0
+	assert len(result.missing_packages) == 0
+
+
+def test_log_entry_fields():
+	entry = LogEntry(level="error", message="test", file="foo.tex", line=10, package="bar")
+	assert entry.level == "error"
+	assert entry.message == "test"
+	assert entry.file == "foo.tex"
+	assert entry.line == 10
+	assert entry.package == "bar"
+
+
+def test_log_entry_defaults():
+	entry = LogEntry(level="warning", message="test")
+	assert entry.file is None
+	assert entry.line is None
+	assert entry.package is None

--- a/tests/test_tinytex_path_resolver.py
+++ b/tests/test_tinytex_path_resolver.py
@@ -10,7 +10,7 @@ def test_failing_resolver(download_tinytex):  # noqa
 	with pytest.raises(RuntimeError):
 		pytinytex._resolve_path("failing")
 	with pytest.raises(RuntimeError):
-		pytinytex.ensure_tinytex_installed("failing", auto_download=False)
+		pytinytex.ensure_tinytex_installed("failing")
 
 def test_successful_resolver(download_tinytex):  # noqa
 	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)

--- a/tests/test_tinytex_runner.py
+++ b/tests/test_tinytex_runner.py
@@ -2,11 +2,13 @@ import pytinytex
 from .utils import download_tinytex, TINYTEX_DISTRIBUTION  # noqa
 
 def test_run_help(download_tinytex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
 	exit_code, output = pytinytex.help()
 	assert exit_code == 0
 	assert "TeX Live" in output
 
 def test_get_version(download_tinytex):  # noqa
+	pytinytex.ensure_tinytex_installed(TINYTEX_DISTRIBUTION)
 	version = pytinytex.get_version()
 	assert isinstance(version, str)
 	assert "TeX Live" in version or "tlmgr" in version


### PR DESCRIPTION
## Summary

- **`compile()`** — Compile `.tex` to PDF with multi-pass support, engine selection (`pdflatex`/`xelatex`/`lualatex`), and automatic installation of missing packages via tlmgr
- **LaTeX log parser** (`parse_log()`) — Extract structured errors, warnings, and missing package names from `.log` files
- **CLI** (`python -m pytinytex` / `pytinytex` command) — All features accessible from the terminal: compile, install, remove, list, search, info, update, version, doctor, download, uninstall
- **`doctor()`** — Health check that verifies TinyTeX installation, PATH, tlmgr, and engine availability
- **Download progress callbacks** — `download_tinytex(progress_callback=...)` for tracking download progress
- **`ensure_tinytex_installed()` no longer auto-downloads** — Raises `RuntimeError` if TinyTeX isn't found instead of silently downloading ~100MB
- **Module refactor** — Split the monolithic `__init__.py` into focused modules: `tlmgr.py`, `doctor.py`, `compiler.py`, `log_parser.py`, `cli.py`
- **Rewritten README** — Showcases all features with clear examples, ordered by usefulness

## New files

| Module | Purpose |
|---|---|
| `pytinytex/tlmgr.py` | Package management, tlmgr command runner, output parsing |
| `pytinytex/doctor.py` | Installation health checks |
| `pytinytex/compiler.py` | LaTeX compilation with auto-install |
| `pytinytex/log_parser.py` | LaTeX log file parser |
| `pytinytex/cli.py` | argparse CLI with all subcommands |
| `pytinytex/__main__.py` | `python -m pytinytex` entry point |
| `tests/test_log_parser.py` | 11 unit tests for log parsing |
| `tests/test_compiler.py` | 9 tests for compilation |
| `tests/test_cli.py` | 3 tests for CLI |
| `tests/test_doctor.py` | 4 tests for health checks |

## Test plan

- [x] All 20 offline unit tests pass locally (log parser, CLI, tlmgr parsing)
- [ ] CI: full test matrix (Linux/macOS/Windows, Python 3.8–3.14)
- [ ] Verify `pytinytex compile` works end-to-end with a real `.tex` file
- [ ] Verify `pytinytex doctor` reports correct status
- [ ] Verify auto-install resolves missing `.sty` packages during compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)